### PR TITLE
Fix spawned futures in the wgpu examples on native

### DIFF
--- a/examples/framework.rs
+++ b/examples/framework.rs
@@ -1,10 +1,9 @@
-use futures::task::LocalSpawn;
+use futures::{task::{LocalSpawn}, executor::{block_on, LocalPool}};
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::{Duration, Instant};
 use winit::{
     event::{self, WindowEvent},
     event_loop::{ControlFlow, EventLoop},
-    window::Window,
 };
 
 #[cfg_attr(rustfmt, rustfmt_skip)]
@@ -55,47 +54,101 @@ pub trait Example: 'static + Sized {
     );
 }
 
-async fn run_async<E: Example, S: LocalSpawn + 'static + Sized>(
-    event_loop: EventLoop<()>,
-    window: Window,
-    spawner: S,
-) {
-    log::info!("Initializing the surface...");
+pub fn run<E: Example>(title: &str) {
+    let event_loop = EventLoop::new();
+    let mut builder = winit::window::WindowBuilder::new();
+    builder = builder.with_title(title);
+    #[cfg(windows_OFF)] // TODO
+    {
+        use winit::platform::windows::WindowBuilderExtWindows;
+        builder = builder.with_no_redirection_bitmap(true);
+    }
+    let window = builder.build(&event_loop).unwrap();
 
-    let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
-    let (size, surface) = unsafe {
-        let size = window.inner_size();
-        let surface = instance.create_surface(&window);
-        (size, surface)
+    #[cfg(not(target_arch = "wasm32"))]
+    let (mut pool, spawner) = {
+        env_logger::init();
+
+        #[cfg(feature = "subscriber")]
+        {
+            let chrome_tracing_dir = std::env::var("WGPU_CHROME_TRACING");
+            wgpu::util::initialize_default_subscriber(chrome_tracing_dir.ok());
+        };
+
+        let local_pool = LocalPool::new();
+        let spawner = local_pool.spawner();
+        (local_pool, spawner)
+    };
+    #[cfg(target_arch = "wasm32")]
+    let spawner = {
+        use futures::{future::LocalFutureObj, task::SpawnError};
+        use winit::platform::web::WindowExtWebSys;
+
+        struct WebSpawner {}
+        impl LocalSpawn for WebSpawner {
+            fn spawn_local_obj(
+                &self,
+                future: LocalFutureObj<'static, ()>,
+            ) -> Result<(), SpawnError> {
+                Ok(wasm_bindgen_futures::spawn_local(future))
+            }
+        }
+
+        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+        console_log::init().expect("could not initialize logger");
+        // On wasm, append the canvas to the document body
+        web_sys::window()
+            .and_then(|win| win.document())
+            .and_then(|doc| doc.body())
+            .and_then(|body| {
+                body.append_child(&web_sys::Element::from(window.canvas()))
+                    .ok()
+            })
+            .expect("couldn't append canvas to document body");
+
+        WebSpawner {}
     };
 
-    let (needed_extensions, unsafe_extensions) = E::needed_extensions();
+    log::info!("Initializing the surface...");
 
-    let adapter = instance
-        .request_adapter(
-            &wgpu::RequestAdapterOptions {
-                power_preference: wgpu::PowerPreference::Default,
-                compatible_surface: Some(&surface),
-            },
-            unsafe_extensions,
-        )
-        .await
-        .unwrap();
+    let (size, surface, instance, adapter, device, queue) = block_on(async {
+        let instance = wgpu::Instance::new(wgpu::BackendBit::PRIMARY);
+        let (size, surface) = unsafe {
+            let size = window.inner_size();
+            let surface = instance.create_surface(&window);
+            (size, surface)
+        };
 
-    let adapter_extensions = adapter.extensions();
+        let (needed_extensions, unsafe_extensions) = E::needed_extensions();
 
-    let trace_dir = std::env::var("WGPU_TRACE");
-    let (device, queue) = adapter
-        .request_device(
-            &wgpu::DeviceDescriptor {
-                extensions: adapter_extensions & needed_extensions,
-                limits: wgpu::Limits::default(),
-                shader_validation: true,
-            },
-            trace_dir.ok().as_ref().map(std::path::Path::new),
-        )
-        .await
-        .unwrap();
+        let adapter = instance
+            .request_adapter(
+                &wgpu::RequestAdapterOptions {
+                    power_preference: wgpu::PowerPreference::Default,
+                    compatible_surface: Some(&surface),
+                },
+                unsafe_extensions,
+            )
+            .await
+            .unwrap();
+
+        let adapter_extensions = adapter.extensions();
+
+        let trace_dir = std::env::var("WGPU_TRACE");
+        let (device, queue) = adapter
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    extensions: adapter_extensions & needed_extensions,
+                    limits: wgpu::Limits::default(),
+                    shader_validation: true,
+                },
+                trace_dir.ok().as_ref().map(std::path::Path::new),
+            )
+            .await
+            .unwrap();
+
+        (size, surface, instance, adapter, device, queue)
+    });
 
     let mut sc_desc = wgpu::SwapChainDescriptor {
         usage: wgpu::TextureUsage::OUTPUT_ATTACHMENT,
@@ -140,6 +193,8 @@ async fn run_async<E: Example, S: LocalSpawn + 'static + Sized>(
                         window.request_redraw();
                         last_update_inst = Instant::now();
                     }
+
+                    pool.run_until_stalled();
                 }
 
                 #[cfg(target_arch = "wasm32")]
@@ -187,75 +242,6 @@ async fn run_async<E: Example, S: LocalSpawn + 'static + Sized>(
             _ => {}
         }
     });
-}
-
-pub fn run<E: Example>(title: &str) {
-    let event_loop = EventLoop::new();
-    let mut builder = winit::window::WindowBuilder::new();
-    builder = builder.with_title(title);
-    #[cfg(windows_OFF)] // TODO
-    {
-        use winit::platform::windows::WindowBuilderExtWindows;
-        builder = builder.with_no_redirection_bitmap(true);
-    }
-    let window = builder.build(&event_loop).unwrap();
-
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        use futures::{
-            executor::{LocalPool, LocalSpawner},
-            task::LocalSpawnExt,
-        };
-
-        env_logger::init();
-
-        #[cfg(feature = "subscriber")]
-        {
-            let chrome_tracing_dir = std::env::var("WGPU_CHROME_TRACING");
-            wgpu::util::initialize_default_subscriber(chrome_tracing_dir.ok());
-        };
-
-        let mut local_pool = LocalPool::new();
-        let spawner = local_pool.spawner();
-        local_pool
-            .spawner()
-            .spawn_local(run_async::<E, LocalSpawner>(event_loop, window, spawner))
-            .unwrap();
-        local_pool.run();
-    }
-    #[cfg(target_arch = "wasm32")]
-    {
-        use futures::{future::LocalFutureObj, task::SpawnError};
-        use winit::platform::web::WindowExtWebSys;
-
-        struct WebSpawner {}
-        impl LocalSpawn for WebSpawner {
-            fn spawn_local_obj(
-                &self,
-                future: LocalFutureObj<'static, ()>,
-            ) -> Result<(), SpawnError> {
-                Ok(wasm_bindgen_futures::spawn_local(future))
-            }
-        }
-
-        std::panic::set_hook(Box::new(console_error_panic_hook::hook));
-        console_log::init().expect("could not initialize logger");
-        // On wasm, append the canvas to the document body
-        web_sys::window()
-            .and_then(|win| win.document())
-            .and_then(|doc| doc.body())
-            .and_then(|body| {
-                body.append_child(&web_sys::Element::from(window.canvas()))
-                    .ok()
-            })
-            .expect("couldn't append canvas to document body");
-
-        wasm_bindgen_futures::spawn_local(run_async::<E, WebSpawner>(
-            event_loop,
-            window,
-            WebSpawner {},
-        ));
-    }
 }
 
 // This allows treating the framework as a standalone example,


### PR DESCRIPTION
This won't win any beauty contests, but it's the best way I could come up with to have the different structures necessary inside `run` to make things work on both native and web.

This is untested on web because in master web does not currently work, but in theory it should work.